### PR TITLE
Fix TradingClient init and ensure cleanup

### DIFF
--- a/datamanager.py
+++ b/datamanager.py
@@ -31,7 +31,7 @@ class DataManager:
             config.ALPACA_API_KEY,
             config.ALPACA_SECRET_KEY,
             paper=True,
-            url=config.BASE_URL,
+            url_override=config.BASE_URL,
         )
         self.data_client = StockHistoricalDataClient(
             config.ALPACA_API_KEY, config.ALPACA_SECRET_KEY
@@ -42,7 +42,7 @@ class DataManager:
     async def morning_prep(self) -> None:
         """Builds the low float universe and retrieves averages."""
         logging.info("Starting morning prep")
-        assets = self.trading_client.get_assets()
+        assets = self.trading_client.get_all_assets()
         symbols = [
             a.symbol
             for a in assets

--- a/main.py
+++ b/main.py
@@ -15,16 +15,16 @@ async def main() -> None:
     )
 
     dm = DataManager()
-    await dm.morning_prep()
-
-    trader = Trader(dm.trading_client)
-
-    async def trade_callback(symbol: str, hod_price: float):
-        await trader.submit_trade(symbol, hod_price)
-
-    scanner = Scanner(dm, trade_callback)
-
     try:
+        await dm.morning_prep()
+
+        trader = Trader(dm.trading_client)
+
+        async def trade_callback(symbol: str, hod_price: float):
+            await trader.submit_trade(symbol, hod_price)
+
+        scanner = Scanner(dm, trade_callback)
+
         await scanner.start()
     finally:
         await dm.close()


### PR DESCRIPTION
## Summary
- use `url_override` when initializing `TradingClient`
- fetch assets with `get_all_assets`
- make `main()` always close the data manager even if prep fails

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`
- `python main.py` *(fails: ProxyError when connecting to Alpaca API)*

------
https://chatgpt.com/codex/tasks/task_e_68435b717fc88327b834b3aeb66cc56e