### PR TITLE
Add trading bot skeleton

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+# Configuration for the trading bot
+
+# Alpaca API credentials
+ALPACA_API_KEY = 'YOUR_ALPACA_API_KEY'
+ALPACA_SECRET_KEY = 'YOUR_ALPACA_SECRET_KEY'
+BASE_URL = 'https://paper-api.alpaca.markets'
+DATA_STREAM_URL = 'wss://stream.data.alpaca.markets/v2/sip'
+
+# Polygon API key
+POLYGON_API_KEY = 'YOUR_POLYGON_API_KEY'
+
+# Risk management and scanner parameters
+POSITION_SIZE = 1000  # dollars per trade
+STOP_LOSS_PCT = 0.025
+TAKE_PROFIT_PCT = 0.05
+
+LOW_FLOAT_THRESHOLD = 10_000_000
+MIN_PRICE = 2.0
+MAX_PRICE = 20.0
+MIN_PCT_CHANGE = 0.10
+MIN_REL_VOLUME = 5
+HOD_PROXIMITY_PCT = 0.03

--- a/datamanager.py
+++ b/datamanager.py
@@ -1,0 +1,86 @@
+"""Data management utilities for the trading bot."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Dict, List
+
+import aiohttp
+from alpaca.data.historical import StockHistoricalDataClient
+from alpaca.data.requests import StockBarsRequest
+from alpaca.data.timeframe import TimeFrame
+from alpaca.trading.client import TradingClient
+
+import config
+
+
+@dataclass
+class AssetInfo:
+    symbol: str
+    prev_close: float
+    avg_volume: float
+
+
+class DataManager:
+    """Handles morning prep and provides reference data."""
+
+    def __init__(self) -> None:
+        self.trading_client = TradingClient(
+            config.ALPACA_API_KEY,
+            config.ALPACA_SECRET_KEY,
+            paper=True,
+            url=config.BASE_URL,
+        )
+        self.data_client = StockHistoricalDataClient(
+            config.ALPACA_API_KEY, config.ALPACA_SECRET_KEY
+        )
+        self.polygon_session = aiohttp.ClientSession()
+        self.low_float_assets: Dict[str, AssetInfo] = {}
+
+    async def morning_prep(self) -> None:
+        """Builds the low float universe and retrieves averages."""
+        logging.info("Starting morning prep")
+        assets = self.trading_client.get_assets()
+        symbols = [
+            a.symbol
+            for a in assets
+            if a.tradable and a.shortable and a.easy_to_borrow and a.exchange in {"NYSE", "NASDAQ"}
+        ]
+
+        tasks = [self._check_low_float(symbol) for symbol in symbols]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for res in results:
+            if isinstance(res, AssetInfo):
+                self.low_float_assets[res.symbol] = res
+        logging.info("Morning prep complete: %s stocks", len(self.low_float_assets))
+
+    async def _check_low_float(self, symbol: str):
+        """Check polygon for shares outstanding and return AssetInfo if low float."""
+        try:
+            url = f"https://api.polygon.io/v3/reference/tickers/{symbol}?apiKey={config.POLYGON_API_KEY}"
+            async with self.polygon_session.get(url) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+        except Exception as exc:  # network or JSON error
+            logging.error("Polygon request failed for %s: %s", symbol, exc)
+            return None
+
+        shares = data.get("results", {}).get("share_class_shares_outstanding")
+        if shares is None or shares >= config.LOW_FLOAT_THRESHOLD:
+            return None
+
+        bars_req = StockBarsRequest(symbol_or_symbols=symbol, timeframe=TimeFrame.Day, limit=50)
+        bars = self.data_client.get_stock_bars(bars_req).data.get(symbol)
+        if not bars:
+            return None
+        avg_volume = sum(b.v for b in bars) / len(bars)
+        prev_close = bars[-1].c
+
+        return AssetInfo(symbol=symbol, prev_close=prev_close, avg_volume=avg_volume)
+
+    async def close(self) -> None:
+        await self.polygon_session.close()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+"""Entrypoint for the trading bot."""
+
+import asyncio
+import logging
+
+import config
+from datamanager import DataManager
+from scanner import Scanner
+from trader import Trader
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+    )
+
+    dm = DataManager()
+    await dm.morning_prep()
+
+    trader = Trader(dm.trading_client)
+
+    async def trade_callback(symbol: str, hod_price: float):
+        await trader.submit_trade(symbol, hod_price)
+
+    scanner = Scanner(dm, trade_callback)
+
+    try:
+        await scanner.start()
+    finally:
+        await dm.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+alpaca-py>=0.7.0
+aiohttp

--- a/scanner.py
+++ b/scanner.py
@@ -1,0 +1,88 @@
+"""Real-time scanning engine using Alpaca streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+from alpaca.data.live import StockDataStream
+from alpaca.data.models import Trade
+
+import config
+from datamanager import AssetInfo, DataManager
+
+
+@dataclass
+class WatchItem:
+    symbol: str
+    hod_proximity: float
+
+
+class Scanner:
+    """Runs the streaming scanner and maintains a dynamic watchlist."""
+
+    def __init__(
+        self,
+        data_manager: DataManager,
+        trade_callback: Callable[[str, float], asyncio.Future],
+    ) -> None:
+        self.dm = data_manager
+        self.trade_callback = trade_callback
+        self.stream = StockDataStream(config.ALPACA_API_KEY, config.ALPACA_SECRET_KEY)
+        self.hod: Dict[str, float] = defaultdict(float)
+        self.volume: Dict[str, int] = defaultdict(int)
+        self.watchlist: List[WatchItem] = []
+        self.running = False
+
+    async def start(self) -> None:
+        """Subscribe to trade updates and start processing."""
+        self.running = True
+        for symbol in self.dm.low_float_assets.keys():
+            self.stream.subscribe_trades(self._on_trade, symbol)
+        logging.info("Starting stream for %d symbols", len(self.dm.low_float_assets))
+        await self.stream.run()
+
+    async def _on_trade(self, trade: Trade):
+        symbol = trade.symbol
+        info = self.dm.low_float_assets.get(symbol)
+        if not info:
+            return
+
+        price = trade.price
+        self.hod[symbol] = max(self.hod[symbol], price)
+        self.volume[symbol] += trade.size
+
+        if self._meets_criteria(symbol, price, info):
+            proximity = 1 - price / self.hod[symbol]
+            self._update_watchlist(symbol, proximity)
+            await self._check_trade_signal()
+
+    def _meets_criteria(self, symbol: str, price: float, info: AssetInfo) -> bool:
+        if not (config.MIN_PRICE <= price <= config.MAX_PRICE):
+            return False
+        if price < info.prev_close * (1 + config.MIN_PCT_CHANGE):
+            return False
+        if self.volume[symbol] < info.avg_volume * config.MIN_REL_VOLUME:
+            return False
+        if self.hod[symbol] == 0:
+            return False
+        if (self.hod[symbol] - price) / self.hod[symbol] > config.HOD_PROXIMITY_PCT:
+            return False
+        return True
+
+    def _update_watchlist(self, symbol: str, proximity: float) -> None:
+        """Add or update symbol in the watchlist sorted by HOD proximity."""
+        self.watchlist = [w for w in self.watchlist if w.symbol != symbol]
+        self.watchlist.append(WatchItem(symbol, proximity))
+        self.watchlist.sort(key=lambda w: w.hod_proximity)
+        logging.debug("Watchlist updated: %s", self.watchlist)
+
+    async def _check_trade_signal(self) -> None:
+        if not self.watchlist:
+            return
+        top = self.watchlist[0]
+        await self.trade_callback(top.symbol, self.hod[top.symbol])
+

--- a/trader.py
+++ b/trader.py
@@ -1,0 +1,53 @@
+"""Order management and trade execution module."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from alpaca.trading.client import TradingClient
+from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
+from alpaca.trading.requests import (
+    MarketOrderRequest,
+    TakeProfitRequest,
+    StopLossRequest,
+    OrderRequest,
+)
+
+import config
+
+
+class Trader:
+    def __init__(self, trading_client: TradingClient) -> None:
+        self.client = trading_client
+        self.open_positions: Dict[str, float] = {}
+
+    def _position_size(self, price: float) -> int:
+        qty = int(config.POSITION_SIZE / price)
+        return max(qty, 1)
+
+    async def submit_trade(self, symbol: str, entry_price: float) -> None:
+        if symbol in self.open_positions:
+            return
+        qty = self._position_size(entry_price)
+        order = OrderRequest(
+            symbol=symbol,
+            qty=qty,
+            side=OrderSide.BUY,
+            type=OrderType.MARKET,
+            time_in_force=TimeInForce.DAY,
+            order_class="bracket",
+            take_profit=TakeProfitRequest(
+                limit_price=round(entry_price * (1 + config.TAKE_PROFIT_PCT), 2)
+            ),
+            stop_loss=StopLossRequest(
+                stop_price=round(entry_price * (1 - config.STOP_LOSS_PCT), 2)
+            ),
+        )
+        try:
+            res = self.client.submit_order(order)
+            self.open_positions[symbol] = entry_price
+            logging.info("Submitted bracket order for %s: %s", symbol, res.id)
+        except Exception as exc:
+            logging.error("Order submission failed for %s: %s", symbol, exc)
+


### PR DESCRIPTION
## Summary
- create a config file for API keys and risk parameters
- add `DataManager` for morning prep and low-float universe building
- add async `Scanner` for real-time trade streams and watchlist handling
- add `Trader` for submitting bracket orders
- wire everything together in `main.py`
- list dependencies in `requirements.txt`

## Testing
- `python3 -m py_compile config.py datamanager.py scanner.py trader.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684358e59b98832798e2acc3b40b1f68