### PR TITLE
Use env vars for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ A simple trading bot that scans low-float stocks using Alpaca's live data.
 2. Start the bot with `python main.py`. It loads the CSV, retrieves historical
    averages from Alpaca and begins streaming trade data for the filtered list.
 
+## Environment Variables
+
+Set the following variables before running any of the scripts:
+
+- `ALPACA_API_KEY` – your Alpaca API key
+- `ALPACA_SECRET_KEY` – your Alpaca secret key
+
+`config.py` reads these values from the environment at runtime.
+
 ## Warning
 
 This project executes live orders if valid API keys are supplied. It is meant

--- a/config.py
+++ b/config.py
@@ -1,8 +1,11 @@
 # Configuration for the trading bot
 
 # Alpaca API credentials
-ALPACA_API_KEY = 'YOUR_ALPACA_API_KEY'
-ALPACA_SECRET_KEY = 'YOUR_ALPACA_SECRET_KEY'
+import os
+
+# Keys are loaded from environment variables so secrets aren't hardcoded
+ALPACA_API_KEY = os.getenv("ALPACA_API_KEY")
+ALPACA_SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = 'https://paper-api.alpaca.markets'
 DATA_STREAM_URL = 'wss://stream.data.alpaca.markets/v2/sip'
 


### PR DESCRIPTION
## Summary
- load Alpaca API credentials from environment variables
- explain required environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68491020d21883278a5c577ff5ac4965