### PR TITLE
Handle DataManager cleanup

### DIFF
--- a/datamanager.py
+++ b/datamanager.py
@@ -71,5 +71,14 @@ class DataManager:
             return None
 
     async def close(self) -> None:
-        pass
+        """Cleanup underlying network sessions."""
+        try:
+            self.trading_client._session.close()
+        except Exception as exc:  # defensive - library may change internals
+            logging.error("Failed to close TradingClient session: %s", exc)
+
+        try:
+            self.data_client._session.close()
+        except Exception as exc:
+            logging.error("Failed to close DataClient session: %s", exc)
 


### PR DESCRIPTION
## Summary
- close Alpaca REST client sessions when DataManager shuts down
- ensure cleanup runs from `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849102630d48327810d0bef50b80a59