### PR TITLE
Use asyncio.to_thread for order submission

### DIFF
--- a/trader.py
+++ b/trader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Dict
 
@@ -45,7 +46,7 @@ class Trader:
             ),
         )
         try:
-            res = self.client.submit_order(order)
+            res = await asyncio.to_thread(self.client.submit_order, order)
             self.open_positions[symbol] = entry_price
             logging.info("Submitted bracket order for %s: %s", symbol, res.id)
         except Exception as exc:


### PR DESCRIPTION
## Summary
- convert `Trader.submit_trade` to offload blocking order submission via `asyncio.to_thread`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849102a396c8327b44c86ddd23be0eb