### PR TITLE
Add order tracking and position updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A simple trading bot that scans low-float stocks using Alpaca's live data.
    defined in `config.py`.
 2. Start the bot with `python main.py`. It loads the CSV, retrieves historical
    averages from Alpaca and begins streaming trade data for the filtered list.
+3. Order IDs are stored when trades are placed and stale positions are cleaned
+   up automatically.
 
 ## Warning
 


### PR DESCRIPTION
## Summary
- track order IDs when submitting trades
- periodically poll Alpaca and remove closed positions
- run position monitor alongside scanner
- document new behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849102ba10883278c67608f8aa68433