### PR TITLE
Implement daily risk limits and dynamic sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A simple trading bot that scans low-float stocks using Alpaca's live data.
    defined in `config.py`.
 2. Start the bot with `python main.py`. It loads the CSV, retrieves historical
    averages from Alpaca and begins streaming trade data for the filtered list.
+   Risk controls such as a daily loss limit, maximum open positions and
+   optional dynamic position sizing can be configured in `config.py`.
 
 ## Warning
 

--- a/config.py
+++ b/config.py
@@ -8,9 +8,20 @@ DATA_STREAM_URL = 'wss://stream.data.alpaca.markets/v2/sip'
 
 
 # Risk management and scanner parameters
-POSITION_SIZE = 1000  # dollars per trade
+POSITION_SIZE = 1000  # dollars per trade (used if SIZE_EQUITY_PCT == 0)
 STOP_LOSS_PCT = 0.025
 TAKE_PROFIT_PCT = 0.05
+
+# Daily loss and position limits
+MAX_DAILY_LOSS = 1000  # dollars
+MAX_POSITIONS = 5
+
+# Dynamic position sizing
+# If SIZE_EQUITY_PCT > 0, position size will be calculated as a percentage of
+# current account equity. Otherwise POSITION_SIZE is used.
+SIZE_EQUITY_PCT = 0.01  # 1% of equity per trade
+USE_VOLATILITY_ADJUST = False  # scale size by VOLATILITY_TARGET / asset_vol
+VOLATILITY_TARGET = 0.02  # target daily vol used when adjusting by volatility
 
 LOW_FLOAT_THRESHOLD = 10_000_000
 MIN_PRICE = 2.0

--- a/datamanager.py
+++ b/datamanager.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Dict
+import statistics
 
 import csv
 from alpaca.data.historical import StockHistoricalDataClient
@@ -21,6 +22,7 @@ class AssetInfo:
     symbol: str
     prev_close: float
     avg_volume: float
+    volatility: float
 
 
 class DataManager:
@@ -65,7 +67,14 @@ class DataManager:
                 return None
             avg_volume = sum(b.v for b in bars) / len(bars)
             prev_close = bars[-1].c
-            return AssetInfo(symbol=symbol, prev_close=prev_close, avg_volume=avg_volume)
+            returns = [(bars[i].c / bars[i-1].c) - 1 for i in range(1, len(bars))]
+            volatility = (statistics.stdev(returns) if len(returns) > 1 else 0)
+            return AssetInfo(
+                symbol=symbol,
+                prev_close=prev_close,
+                avg_volume=avg_volume,
+                volatility=volatility,
+            )
         except Exception as exc:
             logging.error("Data request failed for %s: %s", symbol, exc)
             return None

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ async def main() -> None:
     dm = DataManager()
     await dm.morning_prep()
 
-    trader = Trader(dm.trading_client)
+    trader = Trader(dm.trading_client, dm)
     trader.clear_positions()
 
     async def trade_callback(symbol: str, hod_price: float):


### PR DESCRIPTION
## Summary
- add config options for daily loss limits, position caps and dynamic sizing
- calculate asset volatility during morning prep
- size orders using account equity and optional volatility adjustments
- prevent trades after daily loss limit or when too many positions are open
- mention the new risk controls in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6849102c847c8327811824c8040b9834