### PR TITLE
Add pytest and tests for scanner and trader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 alpaca-py>=0.7.0
 yfinance
+pytest

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import config
+from datamanager import DataManager, AssetInfo
+from scanner import Scanner
+
+
+def _scanner():
+    dm = DataManager()
+    return Scanner(dm, lambda s, p: None)
+
+
+def test_meets_criteria_all_false_cases():
+    scanner = _scanner()
+    symbol = "TEST"
+    info = AssetInfo(symbol=symbol, prev_close=10.0, avg_volume=1000)
+
+    # Price outside min/max
+    scanner.hod[symbol] = 10.5
+    scanner.volume[symbol] = 6000
+    assert not scanner._meets_criteria(symbol, 1.0, info)
+
+    # Price below required pct change
+    scanner.hod[symbol] = 11.0
+    scanner.volume[symbol] = 6000
+    assert not scanner._meets_criteria(symbol, 10.5, info)
+
+    # Insufficient volume
+    scanner.hod[symbol] = 11.0
+    scanner.volume[symbol] = 4000
+    assert not scanner._meets_criteria(symbol, 11.0, info)
+
+    # Missing HOD
+    scanner.hod[symbol] = 0.0
+    scanner.volume[symbol] = 6000
+    assert not scanner._meets_criteria(symbol, 11.0, info)
+
+    # Price too far from HOD
+    scanner.hod[symbol] = 11.0
+    scanner.volume[symbol] = 6000
+    far_price = 11.0 * (1 - config.HOD_PROXIMITY_PCT - 0.01)
+    assert not scanner._meets_criteria(symbol, far_price, info)
+
+
+def test_meets_criteria_success():
+    scanner = _scanner()
+    symbol = "TEST"
+    info = AssetInfo(symbol=symbol, prev_close=10.0, avg_volume=1000)
+    scanner.hod[symbol] = 11.0
+    scanner.volume[symbol] = 6000
+    price = 11.0
+    assert scanner._meets_criteria(symbol, price, info)

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import config
+from trader import Trader
+
+class DummyClient:
+    pass
+
+def test_position_size_basic():
+    trader = Trader(DummyClient())
+    assert trader._position_size(20) == 50
+
+def test_position_size_rounding_and_minimum():
+    trader = Trader(DummyClient())
+    assert trader._position_size(33) == 30
+    assert trader._position_size(1500) == 1


### PR DESCRIPTION
## Summary
- add pytest to project requirements
- unit test the scanner signal criteria
- unit test the trader order sizing logic

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849102d9d048327877d119d26e046b2